### PR TITLE
Clarify LoginPacket protocol fields

### DIFF
--- a/pi_protocol/data/protocol.json
+++ b/pi_protocol/data/protocol.json
@@ -3,8 +3,8 @@
         "id": 130,
         "fields": {
             "username": "String",
-            "protocol1": "IntBE",
-            "protocol2": "IntBE"
+            "protocolClient": "IntBE",
+            "protocolServer": "IntBE"
         }
     },
     "LoginStatusPacket": {


### PR DESCRIPTION
The server checks if both values are more than 9. If the client protocol is less, it returns an outdated client status, and vice versa for the server protocol version